### PR TITLE
Exception for no annotation specified

### DIFF
--- a/retrofit-adapters/rxjava/src/main/java/retrofit/HttpException.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit/HttpException.java
@@ -6,8 +6,8 @@ public final class HttpException extends Exception {
   private final String message;
   private final transient Response<?> response;
 
-  public HttpException(Response<?> response) {
-    super("HTTP " + response.code() + " " + response.message());
+  public HttpException(Response<?> response, String infoForException) {
+    super("HTTP " + response.code() + " " + response.message() + ", " + infoForException);
     this.code = response.code();
     this.message = response.message();
     this.response = response;

--- a/retrofit-adapters/rxjava/src/main/java/retrofit/RxJavaCallAdapterFactory.java
+++ b/retrofit-adapters/rxjava/src/main/java/retrofit/RxJavaCallAdapterFactory.java
@@ -149,14 +149,14 @@ public final class RxJavaCallAdapterFactory implements CallAdapter.Factory {
       return responseType;
     }
 
-    @Override public <R> Observable<R> adapt(Call<R> call) {
+    @Override public <R> Observable<R> adapt(final Call<R> call) {
       return Observable.create(new CallOnSubscribe<>(call)) //
           .flatMap(new Func1<Response<R>, Observable<R>>() {
             @Override public Observable<R> call(Response<R> response) {
               if (response.isSuccess()) {
                 return Observable.just(response.body());
               }
-              return Observable.error(new HttpException(response));
+              return Observable.error(new HttpException(response, call.infoForException()));
             }
           });
     }

--- a/retrofit-adapters/rxjava/src/test/java/retrofit/RxJavaCallAdapterFactoryTest.java
+++ b/retrofit-adapters/rxjava/src/test/java/retrofit/RxJavaCallAdapterFactoryTest.java
@@ -80,7 +80,7 @@ public final class RxJavaCallAdapterFactoryTest {
       fail();
     } catch (RuntimeException e) {
       Throwable cause = e.getCause();
-      assertThat(cause).isInstanceOf(HttpException.class).hasMessage("HTTP 404 OK");
+      assertThat(cause).isInstanceOf(HttpException.class).hasMessage("HTTP 404 OK, Service.observableBody(), HTTP method = GET, relative path template = /");
     }
   }
 

--- a/retrofit-converters/protobuf/src/test/java/retrofit/ProtoConverterFactoryTest.java
+++ b/retrofit-converters/protobuf/src/test/java/retrofit/ProtoConverterFactoryTest.java
@@ -120,7 +120,9 @@ public final class ProtoConverterFactoryTest {
       call.execute();
       fail();
     } catch (RuntimeException e) {
-      assertThat(e.getCause()).isInstanceOf(InvalidProtocolBufferException.class)
+      assertThat(e).isExactlyInstanceOf(RuntimeException.class)
+          .hasMessage("Problem has occurred during conversion of response for Service.get(), HTTP method = GET, relative path template = /");
+      assertThat(e.getCause().getCause()).isInstanceOf(InvalidProtocolBufferException.class)
           .hasMessageContaining("input ended unexpectedly");
     }
   }

--- a/retrofit-converters/simplexml/src/test/java/retrofit/SimpleXmlConverterFactoryTest.java
+++ b/retrofit-converters/simplexml/src/test/java/retrofit/SimpleXmlConverterFactoryTest.java
@@ -79,7 +79,9 @@ public class SimpleXmlConverterFactoryTest {
       call.execute();
       fail();
     } catch (RuntimeException e) {
-      assertThat(e.getCause()).isInstanceOf(ElementException.class)
+      assertThat(e).isExactlyInstanceOf(RuntimeException.class)
+          .hasMessage("Problem has occurred during conversion of response for Service.get(), HTTP method = GET, relative path template = /");
+      assertThat(e.getCause().getCause()).isInstanceOf(ElementException.class)
           .hasMessageStartingWith("Element 'foo' does not have a match in class retrofit.MyObject");
     }
   }
@@ -93,7 +95,9 @@ public class SimpleXmlConverterFactoryTest {
       call.execute();
       fail();
     } catch (RuntimeException e) {
-      assertThat(e).hasMessage("Could not deserialize body as class java.lang.String");
+      assertThat(e).isExactlyInstanceOf(RuntimeException.class)
+          .hasMessage("Problem has occurred during conversion of response for Service.wrongClass(), HTTP method = GET, relative path template = /");
+      assertThat(e.getCause()).hasMessage("Could not deserialize body as class java.lang.String");
     }
   }
 }

--- a/retrofit-mock/src/main/java/retrofit/mock/BehaviorCall.java
+++ b/retrofit-mock/src/main/java/retrofit/mock/BehaviorCall.java
@@ -63,6 +63,11 @@ final class BehaviorCall<T> implements Call<T> {
     return new BehaviorCall<>(retrofit, behavior, backgroundExecutor, delegate.clone());
   }
 
+  @Override
+  public String infoForException() {
+    return delegate.infoForException();
+  }
+
   @Override public void enqueue(final Callback<T> callback) {
     synchronized (this) {
       if (executed) throw new IllegalStateException("Already executed");

--- a/retrofit-mock/src/main/java/retrofit/mock/Calls.java
+++ b/retrofit-mock/src/main/java/retrofit/mock/Calls.java
@@ -44,6 +44,11 @@ public final class Calls {
       @Override public Call<T> clone() {
         return this;
       }
+
+      @Override
+      public String infoForException() {
+        return null;
+      }
     };
   }
 
@@ -63,6 +68,11 @@ public final class Calls {
       @SuppressWarnings("CloneDoesntCallSuperClone") // Immutable object.
       @Override public Call<T> clone() {
         return this;
+      }
+
+      @Override
+      public String infoForException() {
+        return null;
       }
     };
   }

--- a/retrofit/src/main/java/retrofit/Call.java
+++ b/retrofit/src/main/java/retrofit/Call.java
@@ -33,4 +33,5 @@ public interface Call<T> extends Cloneable {
   void enqueue(Callback<T> callback);
   void cancel();
   Call<T> clone();
+  String infoForException();
 }

--- a/retrofit/src/main/java/retrofit/ExecutorCallAdapterFactory.java
+++ b/retrofit/src/main/java/retrofit/ExecutorCallAdapterFactory.java
@@ -69,6 +69,11 @@ final class ExecutorCallAdapterFactory implements CallAdapter.Factory {
     @Override public Call<T> clone() {
       return new ExecutorCallbackCall<>(callbackExecutor, delegate.clone());
     }
+
+    @Override
+    public String infoForException() {
+      return delegate.infoForException();
+    }
   }
 
   static final class ExecutorCallback<T> implements Callback<T> {

--- a/retrofit/src/main/java/retrofit/MethodHandler.java
+++ b/retrofit/src/main/java/retrofit/MethodHandler.java
@@ -19,6 +19,7 @@ import com.squareup.okhttp.ResponseBody;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.Map;
 
 final class MethodHandler<T> {
   @SuppressWarnings("unchecked")
@@ -28,7 +29,9 @@ final class MethodHandler<T> {
     Converter<ResponseBody, Object> responseConverter =
         (Converter<ResponseBody, Object>) createResponseConverter(method, retrofit, responseType);
     RequestFactory requestFactory = RequestFactoryParser.parse(method, responseType, retrofit);
-    return new MethodHandler<>(retrofit, requestFactory, callAdapter, responseConverter);
+    String infoForException = collectInfoForException(method);
+    return new MethodHandler<>(retrofit, requestFactory, callAdapter, responseConverter,
+        infoForException);
   }
 
   private static CallAdapter<?> createCallAdapter(Method method, Retrofit retrofit) {
@@ -58,20 +61,55 @@ final class MethodHandler<T> {
     }
   }
 
+  private static String collectInfoForException(Method method) {
+    Annotation[] annotations = method.getAnnotations();
+
+    String httpMethod = null;
+    String relativePathTemplate = null;
+
+    for (Annotation annotation : annotations) {
+      Map.Entry<String, String> httpMethodAndPathTemplate
+          = Utils.parseHttpMethodAndRelativePathTemplate(annotation);
+
+      if (httpMethodAndPathTemplate != null) {
+        httpMethod = httpMethodAndPathTemplate.getKey();
+        relativePathTemplate = httpMethodAndPathTemplate.getValue();
+        break;
+      }
+    }
+
+    return method.getDeclaringClass().getSimpleName()
+        + "."
+        + method.getName()
+        + "()"
+        + ", HTTP method = "
+        + httpMethod
+        + ", relative path template = "
+        + relativePathTemplate;
+  }
+
+
+
   private final Retrofit retrofit;
   private final RequestFactory requestFactory;
   private final CallAdapter<T> callAdapter;
   private final Converter<ResponseBody, T> responseConverter;
 
+  // Should never include sensitive data such as query params, headers and so on.
+  private final String infoForException;
+
   private MethodHandler(Retrofit retrofit, RequestFactory requestFactory,
-      CallAdapter<T> callAdapter, Converter<ResponseBody, T> responseConverter) {
+      CallAdapter<T> callAdapter, Converter<ResponseBody, T> responseConverter,
+      String infoForException) {
     this.retrofit = retrofit;
     this.requestFactory = requestFactory;
     this.callAdapter = callAdapter;
     this.responseConverter = responseConverter;
+    this.infoForException = infoForException;
   }
 
   Object invoke(Object... args) {
-    return callAdapter.adapt(new OkHttpCall<>(retrofit, requestFactory, responseConverter, args));
+    return callAdapter.adapt(new OkHttpCall<>(retrofit, requestFactory, responseConverter, args,
+        infoForException));
   }
 }

--- a/retrofit/src/main/java/retrofit/OkHttpCall.java
+++ b/retrofit/src/main/java/retrofit/OkHttpCall.java
@@ -66,7 +66,7 @@ final class OkHttpCall<T> implements Call<T> {
     try {
       rawCall = createRawCall();
     } catch (Throwable t) {
-      callback.onFailure(new RuntimeException("Can not create call for " + infoForException, t));
+      callback.onFailure(new RuntimeException("Cannot create call for " + infoForException, t));
       return;
     }
     if (canceled) {

--- a/retrofit/src/main/java/retrofit/RequestFactoryParser.java
+++ b/retrofit/src/main/java/retrofit/RequestFactoryParser.java
@@ -109,7 +109,7 @@ final class RequestFactoryParser {
             httpMethodAndRelativePathTemplate.getValue(),
             hasBody
         );
-      
+
 
       if (annotation instanceof Headers) {
         String[] headersToParse = ((Headers) annotation).value();

--- a/retrofit/src/main/java/retrofit/RequestFactoryParser.java
+++ b/retrofit/src/main/java/retrofit/RequestFactoryParser.java
@@ -95,7 +95,6 @@ final class RequestFactoryParser {
       Map.Entry<String, String> httpMethodAndRelativePathTemplate
           = Utils.parseHttpMethodAndRelativePathTemplate(annotation);
 
-      if (httpMethodAndRelativePathTemplate != null) {
         if (annotation instanceof HEAD && !Void.class.equals(responseType)) {
           throw methodError(method, "HEAD method must use Void as response type.");
         }
@@ -110,7 +109,7 @@ final class RequestFactoryParser {
             httpMethodAndRelativePathTemplate.getValue(),
             hasBody
         );
-      }
+      
 
       if (annotation instanceof Headers) {
         String[] headersToParse = ((Headers) annotation).value();

--- a/retrofit/src/main/java/retrofit/Utils.java
+++ b/retrofit/src/main/java/retrofit/Utils.java
@@ -21,6 +21,8 @@ import com.squareup.okhttp.ResponseBody;
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.lang.annotation.AnnotationFormatError;
+import java.lang.annotation.IncompleteAnnotationException;
 import java.lang.reflect.Array;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
@@ -31,6 +33,8 @@ import java.lang.reflect.WildcardType;
 import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Map;
+
+import com.sun.xml.internal.txw2.IllegalAnnotationException;
 import okio.Buffer;
 import okio.BufferedSource;
 import okio.Source;
@@ -230,7 +234,7 @@ final class Utils {
       httpMethod = ((HTTP) annotation).method();
       path = ((HTTP) annotation).path();
     } else {
-      return null;
+      throw new IllegalAnnotationException("HttpMethod annotation is missing, HttpMethod calls need to be specified");
     }
 
     return new AbstractMap.SimpleImmutableEntry<>(httpMethod, path);

--- a/retrofit/src/main/java/retrofit/Utils.java
+++ b/retrofit/src/main/java/retrofit/Utils.java
@@ -28,10 +28,19 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
+import java.util.AbstractMap;
 import java.util.Arrays;
+import java.util.Map;
 import okio.Buffer;
 import okio.BufferedSource;
 import okio.Source;
+import retrofit.http.DELETE;
+import retrofit.http.GET;
+import retrofit.http.HEAD;
+import retrofit.http.HTTP;
+import retrofit.http.PATCH;
+import retrofit.http.POST;
+import retrofit.http.PUT;
 
 final class Utils {
   static <T> T checkNotNull(T object, String message) {
@@ -194,6 +203,37 @@ final class Utils {
               + "Specify the response body type only (e.g., Call<TweetResponse>).");
     }
     return responseType;
+  }
+
+  static Map.Entry<String, String> parseHttpMethodAndRelativePathTemplate(Annotation annotation) {
+    String httpMethod, path;
+
+    if (annotation instanceof DELETE) {
+      httpMethod = "DELETE";
+      path = ((DELETE) annotation).value();
+    } else if (annotation instanceof GET) {
+      httpMethod = "GET";
+      path = ((GET) annotation).value();
+    } else if (annotation instanceof HEAD) {
+      httpMethod = "HEAD";
+      path = ((HEAD) annotation).value();
+    } else if (annotation instanceof PATCH) {
+      httpMethod = "PATCH";
+      path = ((PATCH) annotation).value();
+    } else if (annotation instanceof POST) {
+      httpMethod = "POST";
+      path = ((POST) annotation).value();
+    } else if (annotation instanceof PUT) {
+      httpMethod = "PUT";
+      path = ((PUT) annotation).value();
+    } else if (annotation instanceof HTTP) {
+      httpMethod = ((HTTP) annotation).method();
+      path = ((HTTP) annotation).path();
+    } else {
+      return null;
+    }
+
+    return new AbstractMap.SimpleImmutableEntry<>(httpMethod, path);
   }
 
   private Utils() {

--- a/retrofit/src/test/java/retrofit/CallTest.java
+++ b/retrofit/src/test/java/retrofit/CallTest.java
@@ -247,7 +247,7 @@ public final class CallTest {
 
     Throwable failure = failureRef.get();
 
-    assertThat(failure).hasMessage("Can not create call for Service.postString(), HTTP method = POST, relative path template = /");
+    assertThat(failure).hasMessage("Cannot create call for Service.postString(), HTTP method = POST, relative path template = /");
     assertThat(failure).hasCauseExactlyInstanceOf(UnsupportedOperationException.class);
     assertThat(failure.getCause()).hasMessage("I am broken!");
   }

--- a/retrofit/src/test/java/retrofit/CallTest.java
+++ b/retrofit/src/test/java/retrofit/CallTest.java
@@ -245,8 +245,11 @@ public final class CallTest {
     });
     assertTrue(latch.await(2, SECONDS));
 
-    assertThat(failureRef.get()).isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("I am broken!");
+    Throwable failure = failureRef.get();
+
+    assertThat(failure).hasMessage("Can not create call for Service.postString(), HTTP method = POST, relative path template = /");
+    assertThat(failure).hasCauseExactlyInstanceOf(UnsupportedOperationException.class);
+    assertThat(failure.getCause()).hasMessage("I am broken!");
   }
 
   @Test public void conversionProblemIncomingSync() throws IOException {
@@ -271,8 +274,10 @@ public final class CallTest {
     try {
       call.execute();
       fail();
-    } catch (UnsupportedOperationException e) {
-      assertThat(e).hasMessage("I am broken!");
+    } catch (RuntimeException e) {
+      assertThat(e).hasMessage("Problem has occurred during conversion of response for Service.postString(), HTTP method = POST, relative path template = /");
+      assertThat(e).hasCauseExactlyInstanceOf(UnsupportedOperationException.class);
+      assertThat(e.getCause()).hasMessage("I am broken!");
     }
   }
 
@@ -357,8 +362,11 @@ public final class CallTest {
     });
     assertTrue(latch.await(2, SECONDS));
 
-    assertThat(failureRef.get()).isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("I am broken!");
+    Throwable failure = failureRef.get();
+
+    assertThat(failure).hasMessage("Problem has occurred during conversion of response for Service.postString(), HTTP method = POST, relative path template = /");
+    assertThat(failure).hasCauseExactlyInstanceOf(UnsupportedOperationException.class);
+    assertThat(failure.getCause()).hasMessage("I am broken!");
   }
 
   @Test public void http204SkipsConverter() throws IOException {

--- a/retrofit/src/test/java/retrofit/ExecutorCallAdapterFactoryTest.java
+++ b/retrofit/src/test/java/retrofit/ExecutorCallAdapterFactoryTest.java
@@ -162,5 +162,10 @@ public final class ExecutorCallAdapterFactoryTest {
     @Override public Call<String> clone() {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public String infoForException() {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
Added an Exception when no annotation for httpMethod is specified, deleted annotation nullcheck in RequestFactorParser
